### PR TITLE
feature: added Page Speed Insights Data Studio connector which I used…

### DIFF
--- a/pagespeed-insights/README.md
+++ b/pagespeed-insights/README.md
@@ -1,47 +1,52 @@
-#  Page Speed Insights Community Connector for Data Studio
+# Page Speed Insights Community Connector for Data Studio
 
 *This is not an official Google product*
 
 This [Data Studio](https://datastudio.google.com) [Community
-Connector](https://developers.google.com/datastudio/connector) lets you see the Google  [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)
-[npm](https://www.npmjs.com/) Score for a given page on your website. 
+Connector](https://developers.google.com/datastudio/connector) lets you see the Google [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) Score for a given page on your website.
 
-This Community
-Connector uses the [Google PageSpeed Insights API](https://developers.google.com/speed/docs/insights/v4/getting-started).
+This Community Connector uses the [Google PageSpeed Insights API](https://developers.google.com/speed/docs/insights/v4/getting-started).
 
 ## Try the Community Connector in Data Studio
 
 You can try out the managed deployment of the latest code: [Google PageSpeed Insights Connector](https://datastudio.google.com/datasources/create?connectorId=AKfycbw1pETrN_hM4lFV3z9pexkrWu9ZZppTxoC6hopYCo9zN_KR1a52HKM5Aws4RKJj4aKN)
 
-# Deploy the Community Connector yourself
+## Deploy the Community Connector yourself
 
 Use the [deployment guide](../deploy.md) to deploy the Community Connector
 yourself. After completing the steps in the deployment guide, 
 
 To use it -
 
-1. you need a free api key from Google which you can get from this [Page Speed Insights tutorial post](https://developers.google.com/speed/docs/insights/v4/first-app)
+1. you need a free API key from Google which you can get from this [Page Speed Insights tutorial post](https://developers.google.com/speed/docs/insights/v4/first-app)
 
 2. Click `Get Key` button
 
-3. Paste the key in once you hve added the [Google PageSpeed Insights Connector](https://datastudio.google.com/datasources/create?connectorId=AKfycbw1pETrN_hM4lFV3z9pexkrWu9ZZppTxoC6hopYCo9zN_KR1a52HKM5Aws4RKJj4aKN)
-
-
+3. Paste the key in once you have added the [Google PageSpeed Insights Connector](https://datastudio.google.com/datasources/create?connectorId=AKfycbw1pETrN_hM4lFV3z9pexkrWu9ZZppTxoC6hopYCo9zN_KR1a52HKM5Aws4RKJj4aKN)
 
 ## Examples and use cases covered in the connector
 
 - **3rd Party Key based authentication**  
-  This community connector requires the use of a third-party 'key' based authentication.  I have also done some rudimentary validating of the key eg checking for blank/ null values.
+  This community connector requires the use of a third-party 'key' based authentication. I have also done some rudimentary validating of the key eg checking for blank/ null values.
 - **Error handling and messaging**  
   Example of using [error handling methods and providing useful error messages
   to users](https://developers.google.com/datastudio/connector/error-handling).
-- **Using a 3rd party Api which returns the configuration as part of the Data Studio results**  
-  The connector uses a 3rd Party api to get the page speed score, but also returns the configuration which was set by the user as a custom dimension. 
+- **Using a 3rd party API which returns the configuration as part of the Data Studio results**  
+  The connector uses a 3rd Party API to get the page speed score, but also returns the configuration which was set by the user as a custom dimension. 
 
-##Roadmap 
-Since this is a Google owned product- I assume (and hope) others in Google/ the web performance / analytics community would like to add more features to it - such as : 
-1. breaking out mobile and desktop score into seperate metrics
+## Support
+
+*This is not an official Google product* so this connector is not supported by Google. If there is an issue - please raise an issue in the [Data Studio Community Connector Github](https://github.com/googledatastudio/community-connectors/issues)
+
+## Roadmap
+
+Since this connector has been created by the open source Data Studio community, we invite others to use, feedback and extend it. If you do extend it, then it would be great if you can share back what you add.( although this is not mandatory)
+
+Some ideas that could be added going forward:
+
+1. Breaking out mobile and desktop score into separate metrics
 2. Listing the rules that are not complied with as a separate set of dimensions to be displayed in a table.  
-3. Other cool ideas to help improve speed of websites. 
+3. Better Error handling, if the Url is not valid or if the API key expires/ goes over quota.
+4. Other cool ideas to help improve speed of websites.
 
 Any feedback - feel free to add issue or tweet me on [@ukdatageek](https://twitter.com/ukdatageek)

--- a/pagespeed-insights/README.md
+++ b/pagespeed-insights/README.md
@@ -1,0 +1,47 @@
+#  Page Speed Insights Community Connector for Data Studio
+
+*This is not an official Google product*
+
+This [Data Studio](https://datastudio.google.com) [Community
+Connector](https://developers.google.com/datastudio/connector) lets you see the Google  [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)
+[npm](https://www.npmjs.com/) Score for a given page on your website. 
+
+This Community
+Connector uses the [Google PageSpeed Insights API](https://developers.google.com/speed/docs/insights/v4/getting-started).
+
+## Try the Community Connector in Data Studio
+
+You can try out the managed deployment of the latest code: [Google PageSpeed Insights Connector](https://datastudio.google.com/datasources/create?connectorId=AKfycbw1pETrN_hM4lFV3z9pexkrWu9ZZppTxoC6hopYCo9zN_KR1a52HKM5Aws4RKJj4aKN)
+
+# Deploy the Community Connector yourself
+
+Use the [deployment guide](../deploy.md) to deploy the Community Connector
+yourself. After completing the steps in the deployment guide, 
+
+To use it -
+
+1. you need a free api key from Google which you can get from this [Page Speed Insights tutorial post](https://developers.google.com/speed/docs/insights/v4/first-app)
+
+2. Click `Get Key` button
+
+3. Paste the key in once you hve added the [Google PageSpeed Insights Connector](https://datastudio.google.com/datasources/create?connectorId=AKfycbw1pETrN_hM4lFV3z9pexkrWu9ZZppTxoC6hopYCo9zN_KR1a52HKM5Aws4RKJj4aKN)
+
+
+
+## Examples and use cases covered in the connector
+
+- **3rd Party Key based authentication**  
+  This community connector requires the use of a third-party 'key' based authentication.  I have also done some rudimentary validating of the key eg checking for blank/ null values.
+- **Error handling and messaging**  
+  Example of using [error handling methods and providing useful error messages
+  to users](https://developers.google.com/datastudio/connector/error-handling).
+- **Using a 3rd party Api which returns the configuration as part of the Data Studio results**  
+  The connector uses a 3rd Party api to get the page speed score, but also returns the configuration which was set by the user as a custom dimension. 
+
+##Roadmap 
+Since this is a Google owned product- I assume (and hope) others in Google/ the web performance / analytics community would like to add more features to it - such as : 
+1. breaking out mobile and desktop score into seperate metrics
+2. Listing the rules that are not complied with as a separate set of dimensions to be displayed in a table.  
+3. Other cool ideas to help improve speed of websites. 
+
+Any feedback - feel free to add issue or tweet me on [@ukdatageek](https://twitter.com/ukdatageek)

--- a/pagespeed-insights/appsscript.json
+++ b/pagespeed-insights/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "GMT",
+  "dependencies": {
+  },
+  "dataStudio": {
+    "name": "Page Speed Insights Score",
+    "logoUrl": "https://www.gstatic.com/images/icons/material/product/2x/pagespeed_64dp.png",
+    "company": "Grant Kemp",
+    "companyUrl": "https://www.connectedwindow.com",
+    "addonUrl": "https://github.com/google/datastudio/tree/master/community-connectors/pagespeed-insights",
+    "supportUrl": "https://github.com/google/datastudio/issues",
+    "description": "PageSpeed Insights analyzes the content of a web page, then generates suggestions to make that page faster. Previously this was available in the Google Analytics Page Speed reports, however it was not easy to access via Data Studio.  Hopefully this free plugin will allow you to surface Page Speed Scores to your internal users and ensure that your site speed is fast for your users. ",
+    "shortDescription": "Get the Page Speed Insights Score for a Url to see how performance optimized your site is",
+    "authType": ["KEY"],
+    "feeType": ["FREE"],
+    "sources": ["pageSpeed_Insights"]
+  }
+}

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -1,4 +1,4 @@
-//NOTE: You can obtain a Google PAge Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v4/first-app
+//NOTE: You can obtain a Google Page Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v4/first-app
 function getAuthType() {
     return {
         "type": "KEY"
@@ -15,13 +15,6 @@ function isAuthValid() {
 function getConfig(request) {
     var config = {
         configParams: [
-            //TODO: Keep this in in case this is a simpler way to show apikey and give users ability to generate one
-            //      {
-            //        name: 'apiKey',
-            //        displayName: 'Api Key',
-            //        helpText: 'Enter the Api Key to use to access Page Speed. Get one from: https://developers.google.com/speed/docs/insights/v4/first-app',
-            //        placeholder: '1231232132131232'
-            //      },
             {
                 name: 'urlTotest',
                 displayName: 'Url to generate a Page Speed Insights Score',
@@ -84,7 +77,6 @@ function getData(request) {
         '&fields=ruleGroups'
     ];
     var url = urlparts.join('');
-    var response = UrlFetchApp.fetch(url);
     var response = UrlFetchApp.fetch(url);
     var parsedResponse = JSON.parse(response);
 

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -1,0 +1,145 @@
+//NOTE: You can obtain a Google PAge Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v4/first-app
+function getAuthType() {
+    return {
+        "type": "KEY"
+    };
+}
+
+function isAuthValid() {
+    var userProperties = PropertiesService.getUserProperties();
+    var key = userProperties.getProperty('dscc.key');
+    var isValid = validateKey(key);
+    return isValid
+}
+
+function getConfig(request) {
+    var config = {
+        configParams: [
+            //TODO: Keep this in in case this is a simpler way to show apikey and give users ability to generate one
+            //      {
+            //        name: 'apiKey',
+            //        displayName: 'Api Key',
+            //        helpText: 'Enter the Api Key to use to access Page Speed. Get one from: https://developers.google.com/speed/docs/insights/v4/first-app',
+            //        placeholder: '1231232132131232'
+            //      },
+            {
+                name: 'urlTotest',
+                displayName: 'Url to generate a Page Speed Insights Score',
+                helpText: 'Enter the webpage url to get the Page Speed.',
+                placeholder: 'http://www.yourdomain.com/page'
+            }
+        ]
+    };
+    return config;
+}
+
+var fixedSchema = [
+
+    {
+        name: 'pageSpeed',
+        label: 'Page Speed Insights Score',
+        dataType: 'NUMBER',
+        semantics: {
+            conceptType: 'METRIC',
+            semanticType: 'NUMBER',
+            isReaggregatable: true
+        },
+        defaultAggregationType: 'AVG'
+    },
+    {
+        name: "weburl",
+        label: "weburlName",
+        description: "The uri of the website being analysed by Page Speed Insights",
+        dataType: "STRING",
+        semantics: {
+            conceptType: "DIMENSION",
+            semanticType: 'TEXT'
+        }
+    }
+];
+
+function getSchema(request) {
+    return { schema: fixedSchema };
+}
+
+function getData(request) {
+
+    // Create schema for requested fields
+    var requestedSchema = request.fields.map(function(field) {
+        for (var i = 0; i < fixedSchema.length; i++) {
+            if (fixedSchema[i].name == field.name) {
+                return fixedSchema[i];
+            }
+        }
+    });
+    // Fetch and parse data from API
+    var userProperties = PropertiesService.getUserProperties();
+    var key = userProperties.getProperty('dscc.key');
+
+    var urlparts = [
+        'https://www.googleapis.com/pagespeedonline/v4/runPagespeed?url=',
+        request.configParams.urlTotest,
+        '&strategy=mobile&key=',
+        key,
+        '&fields=ruleGroups'
+    ];
+    var url = urlparts.join('');
+    var response = UrlFetchApp.fetch(url);
+    var response = UrlFetchApp.fetch(url);
+    var parsedResponse = JSON.parse(response);
+
+    var values = []
+
+    requestedSchema.forEach(function(field) {
+        switch (field.name) {
+            case 'weburl':
+                var urltoTest = request.configParams.urlTotest;
+                values.push(urltoTest)
+                break
+            case 'pageSpeed':
+                var pageSpeed = parsedResponse.ruleGroups.SPEED.score
+                values.push(pageSpeed)
+                break
+            default:
+                values.push('');
+                break
+        }
+    })
+    requestedData = [{ values: values }];
+    return {
+        schema: requestedSchema,
+        rows: requestedData
+    };
+}
+
+function isAdminUser() {
+    return false
+}
+
+function setCredentials(request) {
+    var key = request.key;
+    var validCreds = validateKey(key);
+    if (!validCreds) {
+        return {
+            errorCode: "INVALID_CREDENTIALS"
+        };
+    }
+    var userProperties = PropertiesService.getUserProperties();
+    userProperties.setProperty("dscc.key", key);
+    return {
+        errorCode: "NONE"
+    };
+}
+
+function resetAuth() {
+    var userProperties = PropertiesService.getUserProperties();
+    userProperties.deleteProperty("dscc.key");
+}
+
+function validateKey(key) {
+    if (key == "" || key == null) {
+        return false
+    } else {
+        return true
+    }
+}


### PR DESCRIPTION
… as a learning exercise to learn the api. Additionally I really found it useful to have Page Speed Insights in Google Analytics - so it was useful for our office to have the page speed score displayed for any key pages that we were making changes to - so the whole team could keep an eye on it and report it.

Since this is a Google owned product- I assume (and hope) others in Google/ the web performance / analytics community would like to add more features to it - such as :
1. breaking out mobile and desktop score into separate metrics
2. Listing the rules that are not complied with as a separate set of dimensions to be displayed in a table.
3. Other cool ideas to help improve speed of websites.

Any feedback - feel free to add issue or tweet me on [@ukdatageek](https://twitter.com/ukdatageek)