### PR TITLE
Kaggle Connector Update

### DIFF
--- a/kaggle/README.md
+++ b/kaggle/README.md
@@ -26,7 +26,7 @@ Click [here][managed-deployment] to try the managed deployment.
 
 ## Limitations
 
-- Currently, only CSV files of upto 20MB size are supported.
+- Currently, only CSV files upto 20MB size are supported.
 
 [datastudio]: https://datastudio.google.com
 [community-connector]: https://developers.google.com/datastudio/connector

--- a/kaggle/README.md
+++ b/kaggle/README.md
@@ -12,24 +12,21 @@ the [Kaggle API][kaggle-api].
 
 Click [here][managed-deployment] to try the managed deployment.
 
-## Prerequisites for using Kaggle connector.
+## Prerequisites for using Kaggle connector
+
 1. Sign up for a [Kaggle][kaggle] account.
 1. Go to the 'Account' tab of your user profile
-  (https://www.kaggle.com/{username}/account) and select 'Create API Token'. This will trigger the download of kaggle.json, a file containing your API credentials.
+  (https://www.kaggle.com/{username}/account) and select 'Create API Token'.
+  This will trigger the download of kaggle.json, a file containing your API
+  credentials.
 
-   **Note: Kaggle requires username and password for authentication which can be found in the downloaded kaggle.json file. The username should be used as it is whereas the "key" should be used as password for authentication.** 
-
-## Examples and use cases covered in the connector
-
-- **Error handling and messaging** Example of using [error handling methods and
-  providing useful error messages to users][error-handling].
-- **Using the USER_PASS auth type** Learn more about
-  [getAuthType()][getAuthType]
+   **Note: Kaggle requires username and password for authentication which can
+   be found in the downloaded kaggle.json file. The username should be used as
+   it is whereas the "key" should be used as password for authentication.**
 
 ## Limitations
 
-- **File types supported**</br> 
-   Currently, only CSV datasets are supported.
+- Currently, only CSV files of upto 20MB size are supported.
 
 [datastudio]: https://datastudio.google.com
 [community-connector]: https://developers.google.com/datastudio/connector

--- a/kaggle/README.md
+++ b/kaggle/README.md
@@ -26,7 +26,7 @@ Click [here][managed-deployment] to try the managed deployment.
 
 ## Limitations
 
-- Currently, only CSV files upto 20MB size are supported.
+- Currently, only CSV files up to 20MB size are supported.
 
 [datastudio]: https://datastudio.google.com
 [community-connector]: https://developers.google.com/datastudio/connector

--- a/kaggle/src/appsscript.json
+++ b/kaggle/src/appsscript.json
@@ -7,7 +7,7 @@
     "company": "Google Data Studio Developer Relations",
     "addonUrl": "https://github.com/googledatastudio/community-connectors/tree/master/kaggle",
     "supportUrl": "https://github.com/googledatastudio/community-connectors/issues",
-    "description": "Connect to and visualize Kaggle datasets. This connector supports a single CSV file of upto 20MB size for each data source. Add connector multiple times for multiple data sources. Steps to get your Kaggle API key: https://www.kaggle.com/docs/api#getting-started-installation-&-authentication",
+    "description": "Connect to and visualize Kaggle datasets. This connector supports a single CSV file upto 20MB size for each data source. Add the connector multiple times for multiple data sources. Steps to get your Kaggle API key: https://www.kaggle.com/docs/api#getting-started-installation-&-authentication",
     "sources": ["KAGGLE"]
   }
 }

--- a/kaggle/src/appsscript.json
+++ b/kaggle/src/appsscript.json
@@ -1,21 +1,13 @@
 {
   "timeZone": "America/Los_Angeles",
-  "dependencies": {
-    "libraries": [{
-      "userSymbol": "FirebaseApp",
-      "libraryId": "1hguuh4Zx72XVC1Zldm_vTtcUUKUA6iBUOoGnJUWLfqDWx5WlOJHqYkrt",
-      "version": "28"
-    }]
-  },
   "exceptionLogging": "STACKDRIVER",
   "dataStudio": {
     "name": "Kaggle",
-    "logoUrl": "https://www.kaggle.com/content/v/43edd17f0e8c/kaggle/img/logos/kaggle-logo-transparent.png",
+    "logoUrl": "https://www.kaggle.com/static/images/logos/kaggle-logo-transparent.png",
     "company": "Google Data Studio Developer Relations",
     "addonUrl": "https://github.com/googledatastudio/community-connectors/tree/master/kaggle",
     "supportUrl": "https://github.com/googledatastudio/community-connectors/issues",
-    "description": "Obtain datasets from Kaggle. Steps to get API key can be found in the kaggle documentation on API authentication (https://www.kaggle.com/docs/api#getting-started-installation-&-authentication). Please use the API key as password while using the community connector. As a limitation, we currently support only a single CSV dataset.",
-    "sources": ["KAGGLE"],
-    "privacyPolicyUrl": "www.google.com"
+    "description": "Connect to and visualize Kaggle datasets. This connector supports a single CSV file of upto 20MB size for each data source. Add connector multiple times for multiple data sources. Steps to get your Kaggle API key: https://www.kaggle.com/docs/api#getting-started-installation-&-authentication",
+    "sources": ["KAGGLE"]
   }
 }

--- a/kaggle/src/appsscript.json
+++ b/kaggle/src/appsscript.json
@@ -7,7 +7,7 @@
     "company": "Google Data Studio Developer Relations",
     "addonUrl": "https://github.com/googledatastudio/community-connectors/tree/master/kaggle",
     "supportUrl": "https://github.com/googledatastudio/community-connectors/issues",
-    "description": "Connect to and visualize Kaggle datasets. This connector supports a single CSV file upto 20MB size for each data source. Add the connector multiple times for multiple data sources. Steps to get your Kaggle API key: https://www.kaggle.com/docs/api#getting-started-installation-&-authentication",
+    "description": "Connect to and visualize Kaggle datasets. This connector supports a single CSV file up to 20MB size for each data source. Add the connector multiple times for multiple data sources. Steps to get your Kaggle API key: https://www.kaggle.com/docs/api#getting-started-installation-&-authentication",
     "sources": ["KAGGLE"]
   }
 }

--- a/kaggle/src/connector.js
+++ b/kaggle/src/connector.js
@@ -297,7 +297,7 @@ function isFileTypeSupported(filename) {
   var extension = filename.substring(length - extensionLength, length);
   extension = extension.toLowerCase();
 
-  var fileypeIsSupported = (extension === supportedExtension);
+  var fileTypeIsSupported = (extension === supportedExtension);
 
   return fileTypeIsSupported;
 }

--- a/kaggle/src/connector.js
+++ b/kaggle/src/connector.js
@@ -6,67 +6,59 @@ var connector = {};
 connector.ownerSlug = "unsdsn";
 connector.datasetSlug = "world-happiness";
 connector.fileName = "2016.csv";
+connector.usernameKey = "USERNAME";
+connector.tokenKey = "KEY";
+connector.kaggleUrl = "https://www.kaggle.com";
+connector.apiBaseUrl = connector.kaggleUrl + "/api/v1/";
+connector.apiDownloadSlug = "datasets/download-raw/";
+connector.pingUrl = connector.apiBaseUrl + "competitions/list";
+connector.fileSizeLimitinBytes = 20971520;
 
 function getAuthType() {
   return {
-    type: "USER_PASS"
+    helpUrl: "https://www.kaggle.com/docs/api#authentication",
+    type: "USER_TOKEN"
   };
 }
+
 function getConfig(request) {
   var config = {
-    configParams: [
-      {
+    configParams: [{
         type: "INFO",
         name: "generalInfo",
-        text:
-          'Enter the following information for the desired Kaggle dataset. The kaggle URL for datasets gives the ownerSlug and datasetSlug. For eg: https://www.kaggle.com/{ownerSlug}/{datasetSlug}. Filename can be found under the "Data" tab'
+        text: 'Enter the following information for the desired Kaggle dataset. The kaggle URL for datasets will contain the Owner slug and Dataset slug: https://www.kaggle.com/{ownerSlug}/{datasetSlug}. Filename can be found under the "Data" tab in Kaggle UI.'
       },
       {
         type: "TEXTINPUT",
         name: "ownerSlug",
-        displayName: "Enter owner slug",
+        displayName: "Owner slug",
         placeholder: connector.ownerSlug
       },
       {
         type: "TEXTINPUT",
         name: "datasetSlug",
-        displayName: "Enter dataset slug",
+        displayName: "Dataset slug",
         placeholder: connector.datasetSlug
       },
       {
         type: "TEXTINPUT",
         name: "fileName",
-        displayName: "Enter filename",
+        displayName: "Filename (CSV files only. Include .csv at end.)",
         placeholder: connector.fileName
       }
     ]
   };
   return config;
 }
+
 function getSchema(request) {
   request = validateConfig(request);
-  var result = getFileData(request.configParams);
-  var rawData = result.csvData;
-  var cacheKey = result.cacheKey;
-  var cache = CacheService.getScriptCache();
-  var cachedSchema = JSON.parse(cache.get(cacheKey));
-  if (cachedSchema === null) {
-    var kaggleSchema = buildSchema(rawData, cacheKey);
-    return { schema: kaggleSchema };
+  try {
+    var result = getFileData(request.configParams);
+  } catch (e) {
+    var fileUrl = buildBrowsableFileUrl(request.configParams);
+    throwConnectorError("Please ensure Owner slug, Dataset slug, and Filename are correct. Unable to find file: " + fileUrl, true);
   }
-  return { schema: cachedSchema };
-}
-function validateConfig(request) {
-  request.configParams = request.configParams || {};
-  var config = request.configParams;
-  config.ownerSlug = config.ownerSlug || connector.ownerSlug;
-  config.datasetSlug = config.datasetSlug || connector.datasetSlug;
-  config.fileName = config.fileName || connector.fileName;
-  return request;
-}
-function getData(request) {
-  request = validateConfig(request);
-  var result = getFileData(request.configParams);
   var rawData = result.csvData;
   var cacheKey = result.cacheKey;
   var cache = CacheService.getScriptCache();
@@ -76,7 +68,49 @@ function getData(request) {
   } else {
     var kaggleSchema = cachedSchema;
   }
-  var requestedSchema = request.fields.map(function(field) {
+  return {
+    schema: kaggleSchema
+  };
+}
+
+function validateConfig(request) {
+  request.configParams = request.configParams || {};
+  var config = request.configParams;
+  config.ownerSlug = config.ownerSlug || connector.ownerSlug;
+  config.datasetSlug = config.datasetSlug || connector.datasetSlug;
+  config.fileName = config.fileName || connector.fileName;
+
+  var fileTypeIsSupported = isFileTypeSupported(config.fileName);
+  if (fileTypeIsSupported === false) {
+    throwConnectorError("Only .csv filetypes are supported.", true);
+  }
+
+  var fileIsSmall = isFileSmall(config);
+  if (fileIsSmall === false) {
+    throwConnectorError("Please use smaller than 20MB csv files.", true);
+  }
+
+  return request;
+}
+
+function getData(request) {
+  request = validateConfig(request);
+  try {
+    var result = getFileData(request.configParams);
+  } catch (e) {
+    var fileUrl = buildBrowsableFileUrl(request.configParams);
+    throwConnectorError("Unable to fetch data from file: " + fileUrl, true);
+  }
+  var rawData = result.csvData;
+  var cacheKey = result.cacheKey;
+  var cache = CacheService.getScriptCache();
+  var cachedSchema = JSON.parse(cache.get(cacheKey));
+  if (cachedSchema === null) {
+    var kaggleSchema = buildSchema(rawData, cacheKey);
+  } else {
+    var kaggleSchema = cachedSchema;
+  }
+  var requestedSchema = request.fields.map(function (field) {
     for (var i = 0; i < kaggleSchema.length; i++) {
       if (kaggleSchema[i].name == field.name) {
         return kaggleSchema[i];
@@ -89,6 +123,7 @@ function getData(request) {
     rows: requestedData
   };
 }
+
 function buildSchema(data, cacheKey) {
   var columnNames = data[0];
   var content = data[1];
@@ -101,6 +136,7 @@ function buildSchema(data, cacheKey) {
   cache.put(cacheKey, JSON.stringify(schema));
   return schema;
 }
+
 function mapColumn(index, columnName, content) {
   var field = {};
   field.name = "c" + index;
@@ -117,14 +153,15 @@ function mapColumn(index, columnName, content) {
   }
   return field;
 }
+
 function processData(data, fields) {
   var header = data[0];
-  var dataIndexes = fields.map(function(field) {
+  var dataIndexes = fields.map(function (field) {
     return header.indexOf(field.label);
   });
   var result = [];
   for (var rowIndex = 1; rowIndex < data.length; rowIndex++) {
-    var rowData = dataIndexes.map(function(columnIndex) {
+    var rowData = dataIndexes.map(function (columnIndex) {
       return data[rowIndex][columnIndex];
     });
     result.push({
@@ -133,33 +170,33 @@ function processData(data, fields) {
   }
   return result;
 }
-function getFileData(config) {
-  var userProperties = PropertiesService.getUserProperties();
-  var user = userProperties.getProperty("USERNAME");
-  var key = userProperties.getProperty("KEY");
-  var kaggleAuth = {
-    userName: user,
-    apiToken: key
-  };
-  var ownerSlug = config.ownerSlug;
-  var datasetSlug = config.datasetSlug;
-  var fileName = config.fileName;
-  var url = ["datasets/download-raw", ownerSlug, datasetSlug, fileName].join(
-    "/"
-  );
-  var key = [ownerSlug, datasetSlug, fileName].join("--");
 
-  var response = kaggleFetch(url, kaggleAuth);
+function getFileData(config) {
+  var kaggleAuth = getStoredCredentials();
+
+  var pathElements = [
+    connector.apiDownloadSlug,
+    config.ownerSlug,
+    config.datasetSlug,
+    config.fileName
+  ];
+  var path = pathElements.join("/");
+
+  var response = kaggleFetch(path, kaggleAuth);
   var fileContent = response.getContentText();
   var csvData = Utilities.parseCsv(fileContent);
+
+  pathElements.shift();
+  var cacheKey = pathElements.join("--");
   var result = {
     csvData: csvData,
-    cacheKey: key
+    cacheKey: cacheKey
   };
   return result;
 }
-function kaggleFetch(url, kaggleAuth) {
-  var fullUrl = "https://www.kaggle.com/api/v1/" + url;
+
+function kaggleFetch(path, kaggleAuth) {
+  var fullUrl = connector.apiBaseUrl + path;
   var authParamPlain = kaggleAuth.userName + ":" + kaggleAuth.apiToken;
   var authParamBase64 = Utilities.base64Encode(authParamPlain);
   var options = {
@@ -170,20 +207,19 @@ function kaggleFetch(url, kaggleAuth) {
   var response = UrlFetchApp.fetch(fullUrl, options);
   return response;
 }
+
 function isAuthValid() {
-  var userProperties = PropertiesService.getUserProperties();
-  var userName = userProperties.getProperty("USERNAME");
-  var key = userProperties.getProperty("KEY");
-  return validateCredentials(userName, key);
+  var kaggleAuth = getStoredCredentials();
+  return validateCredentials(kaggleAuth.userName, kaggleAuth.apiToken);
 }
-function validateCredentials(username, key) {
-  if (username === null || key === null) {
+
+function validateCredentials(username, token) {
+  if (username === null || token === null) {
     return false;
   }
 
   // To check if the credentials entered are valid.
-  var ping = "https://www.kaggle.com/api/v1/competitions/list";
-  var authParamPlain = username + ":" + key;
+  var authParamPlain = username + ":" + token;
   var authParamBase64 = Utilities.base64Encode(authParamPlain);
   var options = {
     headers: {
@@ -191,7 +227,7 @@ function validateCredentials(username, key) {
     }
   };
   try {
-    var response = UrlFetchApp.fetch(ping, options);
+    var response = UrlFetchApp.fetch(connector.pingUrl, options);
   } catch (err) {
     return false;
   }
@@ -202,33 +238,104 @@ function validateCredentials(username, key) {
   }
   return false;
 }
-// Added for USER_PASS auth type.
+
+// Added for USER_TOKEN auth type.
 function setCredentials(request) {
-  var creds = request.userPass;
+  var creds = request.userToken;
   var username = creds.username;
-  var key = creds.password;
+  var token = creds.token;
 
   // Optional
   // Check if the provided username and key are valid through a
   // call to your service.
-  var validCreds = validateCredentials(username, key);
-  if (!validCreds) {
+  var validCreds = validateCredentials(username, token);
+  if (validCreds === false) {
     return {
       errorCode: "INVALID_CREDENTIALS"
     };
   }
   var userProperties = PropertiesService.getUserProperties();
-  userProperties.setProperty("USERNAME", username);
-  userProperties.setProperty("KEY", key);
+  userProperties.setProperty(connector.usernameKey, username);
+  userProperties.setProperty(connector.tokenKey, token);
   return {
     errorCode: "NONE"
   };
 }
+
 function resetAuth() {
   var userProperties = PropertiesService.getUserProperties();
-  userProperties.deleteProperty("USERNAME");
-  userProperties.deleteProperty("KEY");
+  userProperties.deleteProperty(connector.usernameKey);
+  userProperties.deleteProperty(connector.tokenKey);
 }
+
 function isAdminUser() {
   return false;
+}
+
+function throwConnectorError(message, userSafe) {
+  userSafe = (typeof userSafe !== "undefined" &&
+    typeof userSafe === "boolean") ? userSafe : false;
+  if (userSafe) {
+    message = "DS_USER:" + message;
+  }
+  throw new Error(message);
+}
+
+function buildBrowsableFileUrl(config) {
+  var datasetUrlElements = [connector.kaggleUrl, config.ownerSlug, config.datasetSlug];
+  var datasetUrl = datasetUrlElements.join("/");
+  var fileUrlElements = [datasetUrl, config.fileName];
+  var fileUrl = fileUrlElements.join("#");
+  return fileUrl;
+}
+
+function isFileTypeSupported(filename) {
+  var supportedExtension = ".csv";
+  var extensionLength = supportedExtension.length;
+
+  var length = filename.length;
+  var extension = filename.substring(length - extensionLength, length);
+  extension = extension.toLowerCase();
+
+  if (extension === supportedExtension) {
+    var fileTypeIsSupported = true;
+  } else {
+    var fileTypeIsSupported = false;
+  }
+  return fileTypeIsSupported;
+}
+
+function getStoredCredentials() {
+  var userProperties = PropertiesService.getUserProperties();
+  var user = userProperties.getProperty(connector.usernameKey);
+  var token = userProperties.getProperty(connector.tokenKey);
+  var kaggleAuth = {
+    userName: user,
+    apiToken: token
+  };
+  return kaggleAuth;
+}
+
+function isFileSmall(config) {
+  var apiPath = "datasets/view";
+  var pathElements = [
+    apiPath,
+    config.ownerSlug,
+    config.datasetSlug
+  ];
+  var fullPath = pathElements.join("/");
+
+  var kaggleAuth = getStoredCredentials();
+  var response = kaggleFetch(fullPath, kaggleAuth);
+  var fileContent = response.getContentText();
+  var csvData = JSON.parse(fileContent);
+  var fileList = csvData.files;
+
+  for (fileIndex = 0; fileIndex < fileList.length; fileIndex++) {
+    var file = fileList[fileIndex];
+    var fileName = file.name;
+    if (fileName === config.fileName) {
+      return (file.totalBytes < connector.fileSizeLimitinBytes);
+    }
+  }
 }

--- a/kaggle/src/connector.js
+++ b/kaggle/src/connector.js
@@ -12,7 +12,7 @@ connector.kaggleUrl = "https://www.kaggle.com";
 connector.apiBaseUrl = connector.kaggleUrl + "/api/v1/";
 connector.apiDownloadSlug = "datasets/download-raw/";
 connector.pingUrl = connector.apiBaseUrl + "competitions/list";
-connector.fileSizeLimitinBytes = 20971520;
+connector.fileSizeLimitInBytes = 20971520;
 
 function getAuthType() {
   return {
@@ -297,11 +297,8 @@ function isFileTypeSupported(filename) {
   var extension = filename.substring(length - extensionLength, length);
   extension = extension.toLowerCase();
 
-  if (extension === supportedExtension) {
-    var fileTypeIsSupported = true;
-  } else {
-    var fileTypeIsSupported = false;
-  }
+  var fileypeIsSupported = (extension === supportedExtension);
+
   return fileTypeIsSupported;
 }
 
@@ -335,7 +332,7 @@ function isFileSmall(config) {
     var file = fileList[fileIndex];
     var fileName = file.name;
     if (fileName === config.fileName) {
-      return (file.totalBytes < connector.fileSizeLimitinBytes);
+      return (file.totalBytes < connector.fileSizeLimitInBytes);
     }
   }
 }


### PR DESCRIPTION
1) Connector now checks for up to 20 MB csv files.
2) Error messages
   - For wrong file path
   - For non-csv files
   - For having greater than 20mb files
   - For failed connection/failed parsing
3) Uses new User/Token authentication
   - Backwards compatible so it won't break or trigger authflow for existing connector users.
4) Auth help button/url (shows a Help button during authentication linking to the API token help page)
5) Updated logo
6) Misc transparent refactoring and code updates (script)