### PR TITLE
Adding aggregated heart rate data for google-fit

### DIFF
--- a/google-fit/src/Connector.js
+++ b/google-fit/src/Connector.js
@@ -143,6 +143,38 @@ connector.SCHEMA = {
       },
     },
   ],
+  heart_rate_daily: [
+    {
+      name: 'StartTime',
+      label: 'Start Time',
+      dataType: 'NUMBER',
+      semantics: {conceptType: 'DIMENSION'},
+    },
+    {
+      name: 'EndTime',
+      label: 'End Time',
+      dataType: 'NUMBER',
+      semantics: {conceptType: 'DIMENSION'},
+    },
+    {
+      name: 'HeartRateAvg',
+      label: 'Heart Rate Average',
+      dataType: 'NUMBER',
+      semantics: {conceptType: 'METRIC'},
+    },
+    {
+      name: 'HeartRateMax',
+      label: 'Heart Rate Max',
+      dataType: 'NUMBER',
+      semantics: {conceptType: 'METRIC'},
+    },
+    {
+      name: 'HeartRateMin',
+      label: 'Heart Rate Min',
+      dataType: 'NUMBER',
+      semantics: {conceptType: 'METRIC'},
+    },
+  ],
 };
 
 /**
@@ -235,6 +267,65 @@ connector.SAMPLE_DATA = {
       },
     ],
   },
+  heart_rate_daily: [ // Aggregated bucket data format.
+    {
+      startTimeMillis: 1522540800000,
+      endTimeMillis: 1522627200000,
+      dataset: [
+        {
+          point: [
+            {
+              startTimeNanos: 1522540800000000000,
+              endTimeNanos: 1522627080000000000,
+              value: [
+                {fpVal: 73.97566063977747},
+                {fpVal: 161.0},
+                {fpVal: 46.0}
+              ],
+            }
+          ]
+        }
+      ]
+    },
+    {
+      startTimeMillis: 1522627200000,
+      endTimeMillis: 1522713600000,
+      dataset: [
+        {
+          point: [
+            {
+              startTimeNanos: 1522627200000000000,
+              endTimeNanos: 1522713480000000000,
+              value: [
+                {fpVal: 72.2865090403338},
+                {fpVal: 168.0},
+                {fpVal: 58.0}
+              ],
+            }
+          ]
+        }
+      ]
+    },
+    {
+      startTimeMillis: 1522713600000,
+      endTimeMillis: 1522800000000,
+      dataset: [
+        {
+          point: [
+            {
+              startTimeNanos: 1522713600000000000,
+              endTimeNanos: 1522799880000000000,
+              value: [
+                {fpVal: 79.14394993045897},
+                {fpVal: 164.0},
+                {fpVal: 56.0}
+              ],
+            }
+          ]
+        }
+      ]
+    },
+  ],
 };
 
 /**
@@ -549,6 +640,65 @@ connector.dataFuncs.heart_rate = function(request, fit, startDate, endDate) {
     data.push({
       values: values,
     });
+  }
+
+  return {
+    schema: dataSchema,
+    rows: data,
+  };
+};
+
+connector.dataFuncs.heart_rate_daily = function(request, fit, startDate, endDate) {
+  // Prepare the schema for the fields requested.
+  var dataSchema = request.fields.map(function(field) {
+    for (var i = 0; i < connector.SCHEMA.heart_rate.length; i++) {
+      if (connector.SCHEMA.heart_rate[i].name == field.name) {
+        return connector.SCHEMA.heart_rate[i];
+      }
+    }
+  });
+
+  if (request.scriptParams && request.scriptParams.sampleExtraction) {
+    var buckets = connector.SAMPLE_DATA.heart_rate;
+  } else {
+    // TODO: Get the data from the Apps Script Cache service if it exists otherwise get the data from the Google Fit API.
+    // See: https://developers.google.com/datastudio/connector/build#fetch_and_return_data_with_getdata
+    var buckets = fit.getHeartRate(startDate, endDate);
+  }
+
+  var data = [];
+  if (!buckets) return { schema: dataSchema, rows: data };
+  for (var i = 0; i < buckets.length; i++) {
+    var values = [];
+    var segment = buckets[i].dataset[0].point[0];
+
+    if (segment) {
+      // Provide values in the order defined by the schema.
+      dataSchema.forEach(function(field) {
+        switch (field.name) {
+          case 'StartTime':
+            values.push(parseInt(segment.startTimeNanos, 10));
+            break;
+          case 'EndTime':
+            values.push(parseInt(segment.endTimeNanos, 10));
+            break;
+          case 'HeartRateAvg':
+            values.push(segment.value[0].fpVal);
+            break;
+          case 'HeartRateMax':
+            values.push(segment.value[1].fpVal);
+            break;
+          case 'HeartRateMin':
+            values.push(segment.value[2].fpVal);
+            break;
+          default:
+            values.push('');
+        }
+      });
+      data.push({
+        values: values,
+      });
+    }
   }
 
   return {

--- a/google-fit/src/Connector.js
+++ b/google-fit/src/Connector.js
@@ -148,31 +148,40 @@ connector.SCHEMA = {
       name: 'StartTime',
       label: 'Start Time',
       dataType: 'NUMBER',
-      semantics: {conceptType: 'DIMENSION'},
+      semantics: {
+        conceptType: 'DIMENSION',
+        semanticGroup: 'DATETIME',
+      },
     },
     {
       name: 'EndTime',
       label: 'End Time',
       dataType: 'NUMBER',
-      semantics: {conceptType: 'DIMENSION'},
+      semantics: {
+        conceptType: 'DIMENSION',
+        semanticGroup: 'DATETIME',
+      },
     },
     {
       name: 'HeartRateAvg',
       label: 'Heart Rate Average',
       dataType: 'NUMBER',
-      semantics: {conceptType: 'METRIC'},
+      defaultAggregationType: 'AVG',
+      semantics: { conceptType: 'METRIC' },
     },
     {
       name: 'HeartRateMax',
       label: 'Heart Rate Max',
       dataType: 'NUMBER',
-      semantics: {conceptType: 'METRIC'},
+      defaultAggregationType: 'MAX',
+      semantics: { conceptType: 'METRIC' },
     },
     {
       name: 'HeartRateMin',
       label: 'Heart Rate Min',
       dataType: 'NUMBER',
-      semantics: {conceptType: 'METRIC'},
+      defaultAggregationType: 'MIN',
+      semantics: { conceptType: 'METRIC' },
     },
   ],
 };
@@ -359,6 +368,10 @@ connector.getConfig = function(request) {
           {
             label: 'Heart Rate',
             value: 'heart_rate',
+          },
+          {
+            label: 'Heart Rate Daily',
+            value: 'heart_rate_daily',
           },
         ],
       },
@@ -651,19 +664,19 @@ connector.dataFuncs.heart_rate = function(request, fit, startDate, endDate) {
 connector.dataFuncs.heart_rate_daily = function(request, fit, startDate, endDate) {
   // Prepare the schema for the fields requested.
   var dataSchema = request.fields.map(function(field) {
-    for (var i = 0; i < connector.SCHEMA.heart_rate.length; i++) {
-      if (connector.SCHEMA.heart_rate[i].name == field.name) {
-        return connector.SCHEMA.heart_rate[i];
+    for (var i = 0; i < connector.SCHEMA.heart_rate_daily.length; i++) {
+      if (connector.SCHEMA.heart_rate_daily[i].name == field.name) {
+        return connector.SCHEMA.heart_rate_daily[i];
       }
     }
   });
 
   if (request.scriptParams && request.scriptParams.sampleExtraction) {
-    var buckets = connector.SAMPLE_DATA.heart_rate;
+    var buckets = connector.SAMPLE_DATA.heart_rate_daily;
   } else {
     // TODO: Get the data from the Apps Script Cache service if it exists otherwise get the data from the Google Fit API.
     // See: https://developers.google.com/datastudio/connector/build#fetch_and_return_data_with_getdata
-    var buckets = fit.getHeartRate(startDate, endDate);
+    var buckets = fit.getHeartRateDaily(startDate, endDate);
   }
 
   var data = [];

--- a/google-fit/src/GoogleFit.js
+++ b/google-fit/src/GoogleFit.js
@@ -217,6 +217,45 @@ GoogleFit.prototype.getHeartRate = function(startTime, endTime) {
   );
 };
 
+GoogleFit.prototype.getHeartRateDaily = function(startTime, endTime) {
+  return getAggregateData(
+    'derived:com.google.heart_rate.bpm:com.google.android.gms:merge_heart_rate_bpm',
+    startTime.getTime(), endTime.getTime()
+  );
+};
+
+var ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+var oneDayMs = 24 * 60 * 60 * 1000;
+
+function fetchAggregateData(dataSourceId, startTimeMs, endTimeMs) {
+  var data = JSON.parse(
+    UrlFetchApp.fetch('https://www.googleapis.com/fitness/v1/users/me/dataset:aggregate', {
+      contentType: 'application/json',
+      headers:     { Authorization: 'Bearer ' + ScriptApp.getOAuthToken() },
+      method:      'post',
+      payload:     JSON.stringify({
+        aggregateBy:     [{ dataSourceId: dataSourceId }],
+        bucketByTime:    { durationMillis: oneDayMs },
+        startTimeMillis: startTimeMs,
+        endTimeMillis:   endTimeMs,
+      }),
+    })
+  );
+  return data.bucket;
+}
+
+function getAggregateData(dataSourceId, startTimeMs, endTimeMs) {
+  var localEndTimeMs = (endTimeMs - startTimeMs > ninetyDaysMs)
+    ? startTimeMs + ninetyDaysMs
+    : endTimeMs;
+
+  var firstPart = fetchAggregateData(dataSourceId, startTimeMs, localEndTimeMs);
+
+  return (endTimeMs === localEndTimeMs)
+    ? firstPart
+    : firstPart.concat(getAggregateData(dataSourceId, localEndTimeMs, endTimeMs));
+};
+
 /**
  * Gets a dataset via the Google Fit API. If successful it returns a
  * Users.dataSources.datasets resource.


### PR DESCRIPTION
The heart_rate connector is useful to get each hr-reading, but it's really a lot of data for doing a longer period's chart, and for me it fails on too much data when e.g. charting one year.

The `heart_rate_daily` added here uses the aggregation endpoint, and fetches it in chunks of 90 days (since that seems to be the maximum allowed duration for the aggregation endpoint), so you can easily chart up min, max, and avg, over the course of several years.

I'm marking this with WIP (Work In Progress) since it does not follow the style in the rest of the code; has no jsdoc and uses local functions instead of prototype functions (which I don't see the point of and is quite counterproductive in my view).

It, however, works for me ;)

Feel free to merge, change, or reject.  I'm using it already, thought someone might be interested.