### PR TITLE
Removed apiDownloadSlug trailing slash

### DIFF
--- a/kaggle/src/connector.js
+++ b/kaggle/src/connector.js
@@ -10,7 +10,7 @@ connector.usernameKey = "USERNAME";
 connector.tokenKey = "KEY";
 connector.kaggleUrl = "https://www.kaggle.com";
 connector.apiBaseUrl = connector.kaggleUrl + "/api/v1/";
-connector.apiDownloadSlug = "datasets/download-raw/";
+connector.apiDownloadSlug = "datasets/download-raw";
 connector.pingUrl = connector.apiBaseUrl + "competitions/list";
 connector.fileSizeLimitInBytes = 20971520;
 


### PR DESCRIPTION
This was creating double slash "/" and breaking the connector.