### PR TITLE
feat: Add basic travis config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+    "extends": "google",
+    "parserOptions": {
+        "ecmaVersion": 6,
+    },
+    "env": {
+        "node": true,
+    },
+    "rules": {
+        "comma-dangle": ["error", "never"],
+        "max-len": ["error", {"code": 100}],
+        "camelcase": "off", // Off for destructuring
+        "async-await/space-after-async": 2,
+        "async-await/space-after-await": 2,
+        "eqeqeq": 2,
+        "guard-for-in": "off",
+        "no-var": "off", // ES3
+        "no-unused-vars": "off" // functions aren't used.
+    },
+    "plugins": ["async-await"]
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,6 @@ module.exports = {
         "comma-dangle": ["error", "never"],
         "max-len": ["error", {"code": 100}],
         "camelcase": "off", // Off for destructuring
-        "async-await/space-after-async": 2,
-        "async-await/space-after-await": 2,
         "eqeqeq": 2,
         "guard-for-in": "off",
         "no-var": "off", // ES3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "node"
+branches:
+  only:
+    - master
+cache:
+  directories:
+  - node_modules/
+script: npm run lint

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "prettier": "prettier --write \"**/*.js\""
+    "prettier": "prettier --write \"**/*.js\"",
+    "lint": "./node_modules/.bin/eslint **/*.gs --quiet"
   },
   "prettier": {
     "singleQuote": true,
@@ -14,6 +15,9 @@
   },
   "devDependencies": {
     "@google/clasp": "^1.4.1",
+    "eslint": "^5.15.1",
+    "eslint-config-google": "^0.12.0",
+    "eslint-plugin-async-await": "^0.0.0",
     "prettier": "^1.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "prettier": "prettier --write \"**/*.js\"",
-    "lint": "./node_modules/.bin/eslint **/*.gs --quiet"
+    "lint": "eslint **/*.js --quiet"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@google/clasp": "^1.4.1",
     "eslint": "^5.15.1",
     "eslint-config-google": "^0.12.0",
-    "eslint-plugin-async-await": "^0.0.0",
     "prettier": "^1.12.1"
   }
 }


### PR DESCRIPTION
- Adds basic linting to Google's style guide
- Adds continuous integration tests via Travis CI (just linting)
  - This will improve the code quality of this repo.
  - (Turn Travis on [here](https://travis-ci.org/googledatastudio/))
    - (Is there a GitHub owner for this GitHub organization?)
  - Current errors: https://travis-ci.org/grant/community-connectors

---

We can add a Travis badge when Travis is turned on.