### PR TITLE
Feature/145 update page speed insightsto v5 api

### DIFF
--- a/pagespeed-insights/README.md
+++ b/pagespeed-insights/README.md
@@ -41,11 +41,17 @@ yourself.
 There are a few next steps that could improve this connector. please feel free
 to open a PR with any of these improvements.
 
-1. Breaking out mobile and desktop score into separate metrics
-1. Listing the rules that are not complied with as a separate set of dimensions
+1. Refactor the Connector to use the new Data connector Service. 
+2. Listing the actual Opportunities that are not complied with as a separate set of dimensions
    to be displayed in a table.
-1. Better error handling when the url is not valid or if the api key expires/
+3. Better error handling when the url is not valid or if the api key expires/
    goes over quota.
+
+## Changelog 
+### Version 2.0
+1. Breaking out mobile and desktop score into separate metrics
+2. Adding the count of the number of opportunities to improve the url
+3. Added a direct link to the actual report on the web
 
 If you have any feedback, feel free to tweet at [@ukdatageek] (the original
 author of this connector), or open an issue in the repo.
@@ -56,8 +62,8 @@ author of this connector), or open an issue in the repo.
 [error handling]: https://developers.google.com/datastudio/connector/error-handling
 [Page Speed Insights Tutorial]: https://developers.google.com/speed/docs/insights/v4/first-app
 [PageSpeed Insights]: https://developers.google.com/speed/pagespeed/insights/
-[Google PageSpeed Insights API]: https://developers.google.com/speed/docs/insights/v4/getting-started
-[production deployment]: https://datastudio.google.com/datasources/create?connectorId=AKfycbxNlR9D-nb_2du5Zm9HfgsdeIrfr42IRY47qrUiApsnKaLq4D9UXDqGwSTrXWLF4S3qRw
+[Google PageSpeed Insights API]: https://developers.google.com/speed/docs/insights/v5/get-started
+[production deployment]: https://datastudio.google.com/datasources/create?connectorId=AKfycbwYBSNglQqisTakQq4ONpnLW1-HWB9VoKCvhlyha8K1Dg_41ep44N45WBuhSt6J3Tyl-g
 [appsscript]: https://script.google.com
 [data studio]: https://datastudio.google.com
 [community connector]: https://developers.google.com/datastudio/connector

--- a/pagespeed-insights/README.md
+++ b/pagespeed-insights/README.md
@@ -56,6 +56,13 @@ to open a PR with any of these improvements.
 If you have any feedback, feel free to tweet at [@ukdatageek] (the original
 author of this connector), or open an issue in the repo.
 
+## To Contribute:
+1. Fork this project and make your changes. 
+2. Make sure you run `prettier --write "**/*.js"` on your code before you push to make your code look great and easy to read. 
+3. Raise an issue in github and describe what you are going to fix 
+4. Push your changes to branch with the issue name in it eg 145/update-api-to-v5
+5. Create a pull request with details of the change
+
 
 [@ukdatageek]: https://twitter.com/ukdatageek
 [Data Studio Community Connector GitHub]: https://github.com/googledatastudio/community-connectors/issues

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -1,4 +1,4 @@
-//NOTE: You can obtain a Google Page Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v5/get-started
+// NOTE: You can obtain a Google Page Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v5/get-started
 function getAuthType() {
   return {
     type: 'KEY'

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -94,9 +94,7 @@ var fixedSchema = [
 ];
 
 function getSchema(request) {
-  return {
-    schema: fixedSchema
-  };
+  return {schema: fixedSchema};
 }
 /**
  * @param {deviceCat} deviceCategory - Can be 'mobile' or 'desktop' only.
@@ -142,14 +140,12 @@ function getData(request) {
         break;
       case 'pageSpeedDesktop':
         var pageSpeedDesktop =
-          parsedResponseDesktop.lighthouseResult.categories.performance.score *
-          100;
+          parsedResponseDesktop.lighthouseResult.categories.performance.score;
         values.push(pageSpeedDesktop);
         break;
       case 'pageSpeedMobile':
         var pageSpeedMobile =
-          parsedResponseMobile.lighthouseResult.categories.performance.score *
-          100;
+          parsedResponseMobile.lighthouseResult.categories.performance.score;
         values.push(pageSpeedMobile);
         break;
       case 'OpportunitiesDesktop':
@@ -174,11 +170,7 @@ function getData(request) {
     }
   });
 
-  requestedData = [
-    {
-      values: values
-    }
-  ];
+  requestedData = [{values: values}];
   return {
     schema: requestedSchema,
     rows: requestedData
@@ -240,7 +232,6 @@ function buildOpportunities(audits) {
   }
   return audits;
 }
-
 function validateKey(key) {
   if (key == '' || key == null) {
     return false;

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -14,17 +14,20 @@ function isAuthValid() {
 
 function getConfig(request) {
   var config = {
-    configParams: [{
-      name: 'urlTotest',
-      displayName: 'Url to generate a Page Speed Insights Score',
-      helpText: 'Enter the webpage url to get the Page Speed.',
-      placeholder: 'https://www.yourdomain.com/page'
-    }]
+    configParams: [
+      {
+        name: 'urlTotest',
+        displayName: 'Url to generate a Page Speed Insights Score',
+        helpText: 'Enter the webpage url to get the Page Speed.',
+        placeholder: 'https://www.yourdomain.com/page'
+      }
+    ]
   };
   return config;
 }
 
-var fixedSchema = [{
+var fixedSchema = [
+  {
     name: 'pageSpeedDesktop',
     label: 'PS Insights Desktop Score',
     dataType: 'NUMBER',
@@ -101,7 +104,7 @@ function getSchema(request) {
 
 function getData(request) {
   // Create schema for requested fields
-  var requestedSchema = request.fields.map(function (field) {
+  var requestedSchema = request.fields.map(function(field) {
     for (var i = 0; i < fixedSchema.length; i++) {
       if (fixedSchema[i].name == field.name) {
         return fixedSchema[i];
@@ -115,7 +118,7 @@ function getData(request) {
 
   var values = [];
   // Note Would be nice to do this with promises however this doesn't seem to work with Data Studio Connectors - I just get an error
-  var urlMobile = buildUrl('mobile', key, urlToTest)
+  var urlMobile = buildUrl('mobile', key, urlToTest);
   var responseMobile = UrlFetchApp.fetch(urlMobile);
   var parsedResponseMobile = JSON.parse(responseMobile);
 
@@ -127,38 +130,41 @@ function getData(request) {
   var responseDesktop = UrlFetchApp.fetch(urlDesktop);
   var parsedResponseDesktop = JSON.parse(responseDesktop);
 
-
   // Get Opportunities Desktop
   var ruleResultsDesktop = parsedResponseDesktop.lighthouseResult.audits;
   var opportunitiesDesktop = buildOpportunities(ruleResultsDesktop);
 
-
-
-  requestedSchema.forEach(function (field) {
+  requestedSchema.forEach(function(field) {
     switch (field.name) {
       case 'weburl':
         var urltoTest = request.configParams.urlTotest;
         values.push(urltoTest);
         break;
       case 'pageSpeedDesktop':
-        var pageSpeedDesktop = parsedResponseDesktop.lighthouseResult.categories.performance.score * 100;
+        var pageSpeedDesktop =
+          parsedResponseDesktop.lighthouseResult.categories.performance.score *
+          100;
         values.push(pageSpeedDesktop);
         break;
       case 'pageSpeedMobile':
-        var pageSpeedMobile = parsedResponseMobile.lighthouseResult.categories.performance.score * 100;
+        var pageSpeedMobile =
+          parsedResponseMobile.lighthouseResult.categories.performance.score *
+          100;
         values.push(pageSpeedMobile);
         break;
       case 'OpportunitiesDesktop':
-        var desktopCount = Object.keys(opportunitiesDesktop).length
+        var desktopCount = Object.keys(opportunitiesDesktop).length;
         values.push(desktopCount);
         break;
       case 'OpportunitiesMobile':
-        var mobileCount = Object.keys(opportunitiesMobile).length
+        var mobileCount = Object.keys(opportunitiesMobile).length;
         values.push(mobileCount);
         break;
       case 'webReport':
         var urltoTest = request.configParams.urlTotest;
-        var webReportUrl = "https://developers.google.com/speed/pagespeed/insights/?url=" + urltoTest;
+        var webReportUrl =
+          'https://developers.google.com/speed/pagespeed/insights/?url=' +
+          urltoTest;
         values.push(webReportUrl);
         break;
 
@@ -168,10 +174,11 @@ function getData(request) {
     }
   });
 
-
-  requestedData = [{
-    values: values
-  }];
+  requestedData = [
+    {
+      values: values
+    }
+  ];
   return {
     schema: requestedSchema,
     rows: requestedData
@@ -220,11 +227,14 @@ function buildOpportunities(audits) {
   var opportunityThreshold = 0;
 
   for (var key in audits) {
-    if (typeof audits[key].details === "undefined") {
-      delete audits[key]
+    if (typeof audits[key].details === 'undefined') {
+      delete audits[key];
     } else {
-      if (audits[key].details.type != "opportunity" || audits[key].details.overallSavingsMs == opportunityThreshold) {
-        delete audits[key]
+      if (
+        audits[key].details.type != 'opportunity' ||
+        audits[key].details.overallSavingsMs == opportunityThreshold
+      ) {
+        delete audits[key];
       }
     }
   }
@@ -237,5 +247,4 @@ function validateKey(key) {
   } else {
     return true;
   }
-
 }

--- a/pagespeed-insights/main.js
+++ b/pagespeed-insights/main.js
@@ -1,4 +1,4 @@
-// NOTE: You can obtain a Google Page Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v4/first-app
+//NOTE: You can obtain a Google Page Speed Insights API Key from here: https://developers.google.com/speed/docs/insights/v5/get-started
 function getAuthType() {
   return {
     type: 'KEY'
@@ -14,22 +14,52 @@ function isAuthValid() {
 
 function getConfig(request) {
   var config = {
-    configParams: [
-      {
-        name: 'urlTotest',
-        displayName: 'Url to generate a Page Speed Insights Score',
-        helpText: 'Enter the webpage url to get the Page Speed.',
-        placeholder: 'http://www.yourdomain.com/page'
-      }
-    ]
+    configParams: [{
+      name: 'urlTotest',
+      displayName: 'Url to generate a Page Speed Insights Score',
+      helpText: 'Enter the webpage url to get the Page Speed.',
+      placeholder: 'https://www.yourdomain.com/page'
+    }]
   };
   return config;
 }
 
-var fixedSchema = [
+var fixedSchema = [{
+    name: 'pageSpeedDesktop',
+    label: 'PS Insights Desktop Score',
+    dataType: 'NUMBER',
+    semantics: {
+      conceptType: 'METRIC',
+      semanticType: 'NUMBER',
+      isReaggregatable: true
+    },
+    defaultAggregationType: 'AVG'
+  },
   {
-    name: 'pageSpeed',
-    label: 'Page Speed Insights Score',
+    name: 'pageSpeedMobile',
+    label: 'PS Insights Mobile Score',
+    dataType: 'NUMBER',
+    semantics: {
+      conceptType: 'METRIC',
+      semanticType: 'NUMBER',
+      isReaggregatable: true
+    },
+    defaultAggregationType: 'AVG'
+  },
+  {
+    name: 'OpportunitiesMobile',
+    label: 'Opportunities - Mobile',
+    dataType: 'NUMBER',
+    semantics: {
+      conceptType: 'METRIC',
+      semanticType: 'NUMBER',
+      isReaggregatable: true
+    },
+    defaultAggregationType: 'AVG'
+  },
+  {
+    name: 'OpportunitiesDesktop',
+    label: 'Opportunities - Desktop',
     dataType: 'NUMBER',
     semantics: {
       conceptType: 'METRIC',
@@ -47,16 +77,31 @@ var fixedSchema = [
       conceptType: 'DIMENSION',
       semanticType: 'TEXT'
     }
+  },
+  {
+    name: 'webReport',
+    label: 'Insights Web Report',
+    description: 'The uri of for the full Pagespeed Insights report',
+    dataType: 'STRING',
+    semantics: {
+      conceptType: 'DIMENSION',
+      semanticType: 'URL'
+    }
   }
 ];
 
 function getSchema(request) {
-  return {schema: fixedSchema};
+  return {
+    schema: fixedSchema
+  };
 }
+/**
+ * @param {deviceCat} deviceCategory - Can be 'mobile' or 'desktop' only.
+ */
 
 function getData(request) {
   // Create schema for requested fields
-  var requestedSchema = request.fields.map(function(field) {
+  var requestedSchema = request.fields.map(function (field) {
     for (var i = 0; i < fixedSchema.length; i++) {
       if (fixedSchema[i].name == field.name) {
         return fixedSchema[i];
@@ -66,36 +111,67 @@ function getData(request) {
   // Fetch and parse data from API
   var userProperties = PropertiesService.getUserProperties();
   var key = userProperties.getProperty('dscc.key');
-
-  var urlparts = [
-    'https://www.googleapis.com/pagespeedonline/v4/runPagespeed?url=',
-    request.configParams.urlTotest,
-    '&strategy=mobile&key=',
-    key,
-    '&fields=ruleGroups'
-  ];
-  var url = urlparts.join('');
-  var response = UrlFetchApp.fetch(url);
-  var parsedResponse = JSON.parse(response);
+  var urlToTest = request.configParams.urlTotest;
 
   var values = [];
+  // Note Would be nice to do this with promises however this doesn't seem to work with Data Studio Connectors - I just get an error
+  var urlMobile = buildUrl('mobile', key, urlToTest)
+  var responseMobile = UrlFetchApp.fetch(urlMobile);
+  var parsedResponseMobile = JSON.parse(responseMobile);
 
-  requestedSchema.forEach(function(field) {
+  // Get Opportunities
+  var ruleResultsMobile = parsedResponseMobile.lighthouseResult.audits;
+  var opportunitiesMobile = buildOpportunities(ruleResultsMobile);
+
+  var urlDesktop = buildUrl('desktop', key, urlToTest);
+  var responseDesktop = UrlFetchApp.fetch(urlDesktop);
+  var parsedResponseDesktop = JSON.parse(responseDesktop);
+
+
+  // Get Opportunities Desktop
+  var ruleResultsDesktop = parsedResponseDesktop.lighthouseResult.audits;
+  var opportunitiesDesktop = buildOpportunities(ruleResultsDesktop);
+
+
+
+  requestedSchema.forEach(function (field) {
     switch (field.name) {
       case 'weburl':
         var urltoTest = request.configParams.urlTotest;
         values.push(urltoTest);
         break;
-      case 'pageSpeed':
-        var pageSpeed = parsedResponse.ruleGroups.SPEED.score;
-        values.push(pageSpeed);
+      case 'pageSpeedDesktop':
+        var pageSpeedDesktop = parsedResponseDesktop.lighthouseResult.categories.performance.score * 100;
+        values.push(pageSpeedDesktop);
         break;
+      case 'pageSpeedMobile':
+        var pageSpeedMobile = parsedResponseMobile.lighthouseResult.categories.performance.score * 100;
+        values.push(pageSpeedMobile);
+        break;
+      case 'OpportunitiesDesktop':
+        var desktopCount = Object.keys(opportunitiesDesktop).length
+        values.push(desktopCount);
+        break;
+      case 'OpportunitiesMobile':
+        var mobileCount = Object.keys(opportunitiesMobile).length
+        values.push(mobileCount);
+        break;
+      case 'webReport':
+        var urltoTest = request.configParams.urlTotest;
+        var webReportUrl = "https://developers.google.com/speed/pagespeed/insights/?url=" + urltoTest;
+        values.push(webReportUrl);
+        break;
+
       default:
         values.push('');
         break;
     }
   });
-  requestedData = [{values: values}];
+
+
+  requestedData = [{
+    values: values
+  }];
   return {
     schema: requestedSchema,
     rows: requestedData
@@ -126,10 +202,40 @@ function resetAuth() {
   userProperties.deleteProperty('dscc.key');
 }
 
+function buildUrl(deviceCat, key, urlToTest) {
+  var urlparts = [
+    'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=',
+    urlToTest,
+    '&strategy=',
+    deviceCat,
+    '&key=',
+    key,
+    '&category=performance'
+  ];
+  var url = urlparts.join('');
+  return url;
+}
+
+function buildOpportunities(audits) {
+  var opportunityThreshold = 0;
+
+  for (var key in audits) {
+    if (typeof audits[key].details === "undefined") {
+      delete audits[key]
+    } else {
+      if (audits[key].details.type != "opportunity" || audits[key].details.overallSavingsMs == opportunityThreshold) {
+        delete audits[key]
+      }
+    }
+  }
+  return audits;
+}
+
 function validateKey(key) {
   if (key == '' || key == null) {
     return false;
   } else {
     return true;
   }
+
 }


### PR DESCRIPTION
Updated the Page Speed insights to run v5 of api so we can get lighthouse data in. 
Updated the metrics to work with my new radial score card Custom Visualisation 
- split the page speed score into desktop / mobile
- did a count of the number of opportunities to improve
- Added a link to see the full report and updated Readme with new information
- admin: ran prettier
- admin: fixed linting errors




<img width="893" alt="Radial Scorecard" src="https://user-images.githubusercontent.com/751115/54918806-19e77a80-4ef7-11e9-8107-ba5df5de5e8c.png">


