### PR TITLE
Fix CrUX trailing slash removal

### DIFF
--- a/chrome-ux-report/src/Code.js
+++ b/chrome-ux-report/src/Code.js
@@ -485,7 +485,7 @@ function validateUrl(configParams) {
   // Remove '/' at the end
   var lastChar = url.substring(url.length - 1);
   if (lastChar === '/') {
-    url = url.substring(0, url.length - 2);
+    url = url.substring(0, url.length - 1);
   }
 
   // Add 'https://' at the beginning if needed


### PR DESCRIPTION
The current behavior is to remove too much from the end of the URL: 

```js
url = 'https://www.example.com/';
url.substring(0, url.length - 2); // "https://www.example.co"
```

Fixes #173 