### PR TITLE
Fix variable in field discovery

### DIFF
--- a/fetch-csv/src/main.js
+++ b/fetch-csv/src/main.js
@@ -140,7 +140,7 @@ function getFields(request, content) {
       1,
       firstLineContent.length - 1
     );
-    separator = textQualifier + valueSeparator + textQualifier;
+    valueSeparator = textQualifier + valueSeparator + textQualifier;
   }
   var firstLineColumns = firstLineContent.split(valueSeparator);
 


### PR DESCRIPTION
Header row discovery was not working with text qualifiers due to a mislabeled variable.  It would not remove qualifiers from anywhere except the first and last character of the line.