### PR TITLE
Add more restrictive regex checking to validate the fields entered

### DIFF
--- a/gke-usage-metering/src/gkeUsageMetering.ts
+++ b/gke-usage-metering/src/gkeUsageMetering.ts
@@ -141,7 +141,10 @@ namespace gkeUsageMetering {
         .setText('The resource usage dataset ID is not specified')
         .throwException();
     }
-    if (fullResourceUsageDataset.indexOf('.') < 0) {
+    // fullResourceUsageDataset should be in the format of ${PROJECT_ID}.${DATASET_ID}.
+    // GCP project ID can contain letters, numbers, single quotes, hyphens, spaces or
+    // exclamation points; BigQuery dataset IDs can contain letters, numbers and underscores
+    if (!fullResourceUsageDataset.match(/^[a-z][a-z-\d]{5,29}\.[a-zA-Z_\d]{1,1024}$/)) {
       return connector
         .newUserError()
         .setText('Invalid resource usage dataset ID: dataset ID must be in the format of \"${PROJECT_ID}.${DATASET_ID}\}"')
@@ -155,7 +158,9 @@ namespace gkeUsageMetering {
         .setText('The GCP billing table ID is not specified')
         .throwException();
     }
-    if ((fullBillingTable.match(/\./g) || []).length != 2) {
+    // fullBillingTable should be in the format of ${PROJECT_ID}.${DATASET_ID}.${TABLE_ID}.
+    // Bigquery table IDs can contain letters, numbers and underscores.
+    if (!fullBillingTable.match(/^[a-z][a-z-\d]{5,29}\.[a-zA-Z_\d]{1,1024}\.[a-zA-Z_\d]{1,1024}$/)) {
       return connector
         .newUserError()
         .setText('Invalid GCP billing table ID: table ID must be in the format of \"${PROJECT_ID}.${DATASET_ID}.${TABLE_ID}\"')


### PR DESCRIPTION
The purpose is to check for allowed characters in BigQuery dataset
and table IDs and GCP project names to reduce chances of user typos,
and to a certain extent prevent SQL injection.