### PR TITLE
Fix fetch csv

### DIFF
--- a/fetch-csv/src/main.js
+++ b/fetch-csv/src/main.js
@@ -172,7 +172,7 @@ function getData(request) {
     return field.name;
   });
   var fields = getFields(request, content);
-  var requestedFields = fields.forIds(requestedFieldIds);
+  // var requestedFields = fields.forIds(requestedFieldIds);
   var buildedFields = fields.build();
 
   var requestedFieldsIndex = buildedFields.reduce(function(
@@ -234,9 +234,23 @@ function getData(request) {
   }
 
   var result = {
-    schema: requestedFields.build(),
+    schema:  fixInvalidOrder(requestedFieldIds, buildedFields),
     rows: rows
   };
 
   return result;
+}
+
+/**
+ * @param {String[]} fieldsIdsFromRequest Array of requested fields ids.
+ * @param {Object[]} fieldsInOrderFromCsvFile fields.build() return value.
+ * @returns {Object[]}.
+ */
+function fixInvalidOrder(
+    fieldsIdsFromRequest,
+    fieldsInOrderFromCsvFile
+) {
+  return fieldsInOrderFromCsvFile.filter(function (fieldFromCsvFile) {
+    return fieldsIdsFromRequest.indexOf(fieldFromCsvFile.name) >= 0;
+  });
 }

--- a/fetch-csv/src/main.js
+++ b/fetch-csv/src/main.js
@@ -172,7 +172,6 @@ function getData(request) {
     return field.name;
   });
   var fields = getFields(request, content);
-  // var requestedFields = fields.forIds(requestedFieldIds);
   var buildedFields = fields.build();
 
   var requestedFieldsIndex = buildedFields.reduce(function(
@@ -234,7 +233,7 @@ function getData(request) {
   }
 
   var result = {
-    schema:  fixInvalidOrder(requestedFieldIds, buildedFields),
+    schema: fixInvalidOrder(requestedFieldIds, buildedFields),
     rows: rows
   };
 


### PR DESCRIPTION
When I was using `fetch-csv connector` I spotted that there is a bug with an order of columns returned to Data Studio. 

The problem here was that in `Response` object in schema property the order of columns comes from `Request` object. But the order of values in `rows` property in `Response` object comes from csv file.

I deleted a line: `var requestedFields = fields.forIds(requestedFieldIds);`
And wrote a function which generates proper schema based on order from csv file: `fixInvalidOrder`

For testing I used simple csv file: [example.csv](https://raw.githubusercontent.com/piotrek94/random/master/example.csv)


I also attached two screenshots. One with a table before applying the fix and one after.

![before](https://user-images.githubusercontent.com/9871431/62565263-bbf47780-b886-11e9-92cb-2cb4477f9182.png)
![after](https://user-images.githubusercontent.com/9871431/62565260-bbf47780-b886-11e9-83d2-0fb131a68394.png)
