### PR TITLE
Fix order bug in fetch-csv connector.

### DIFF
--- a/fetch-csv/src/main.js
+++ b/fetch-csv/src/main.js
@@ -234,9 +234,20 @@ function getData(request) {
   }
 
   var result = {
-    schema: requestedFields.build(),
+    schema: getAnOrderFromCsvFile(requestedFieldIds, buildedFields),
     rows: rows
   };
 
   return result;
+}
+
+/**
+ * @param {String[]} fieldsIdsFromRequest Array of requested fields ids.
+ * @param {Object[]} fieldsInOrderFromCsvFile fields.build() return value.
+ * @returns {Object[]}.
+ */
+function getAnOrderFromCsvFile(fieldsIdsFromRequest, fieldsInOrderFromCsvFile) {
+  return fieldsInOrderFromCsvFile.filter(function(fieldFromCsvFile) {
+    return fieldsIdsFromRequest.indexOf(fieldFromCsvFile.name) >= 0;
+  });
 }


### PR DESCRIPTION
When I was using `fetch-csv connector` I spotted that there is a bug with an order of columns returned to Data Studio. 

The problem here was that in `Response` object in schema property the order of columns comes from `Request` object. But the order of values in `rows` property in `Response` object comes from csv file.

I deleted a line:
```javascript
var requestedFields = fields.forIds(requestedFieldIds);
```
And wrote a function which generates proper schema based on order from csv file: `fixInvalidOrder`

For testing I used simple csv file: [example.csv](https://raw.githubusercontent.com/piotrek94/random/39d3cdfaf65aa2484a91e42c87e3a04a3a8459a9/example.csv)
Here the content of csv file:
```
Column 2,Column 1,Column 4,Date,Column 3
20,10,40,20190805,30
21,11,41,20190804,31
22,12,42,20190803,32
23,13,43,20190802,33
```

I also attached two screenshots. 
One with a table before applying the fix:
![1before](https://user-images.githubusercontent.com/9871431/62703129-c75fb400-b9e8-11e9-82c7-8f6790cc8aad.png)


And one after fixing:
![1after](https://user-images.githubusercontent.com/9871431/62702685-b82c3680-b9e7-11e9-8a37-f685d1022e7e.png)


