### PR TITLE
SendGrid's Global Stats Community Connector

### DIFF
--- a/sendgrid/README.md
+++ b/sendgrid/README.md
@@ -1,0 +1,66 @@
+# SendGrid Community Connector for Data Studio
+
+*This is not an official Google product*
+
+This [Data Studio](https://datastudio.google.com) [Community Connector](https://developers.google.com/datastudio/connector) lets you connect to [SendGrid](https://sendgrid.com/)'s [Global Stats API](https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/global.html) and provide all of your user’s email statistics for a given date range.
+
+![sendgrid-global-stats-data-studio-template](https://raw.githubusercontent.com/schoraria911/gds-community-connectors/master/SendGrid/Global%20Stats/images/sendgrid-global-stats-data-studio-template.png)
+*This visualisation is based on a [dummy data set](https://docs.google.com/spreadsheets/d/1SRjFAKN0qJGWjHy_wZNqz8n6Hrjg0NTlx14VXqTaMpc/edit?usp=sharing) that mimics the API response data structure*.
+
+## Set up the Community Connector for personal use
+
+To use this Community Connector in Data Studio there is a one-time setup to deploy your own personal instance of the connector using [Apps Script](https://developers.google.com/apps-script).
+
+### Deploy the connector
+
+#### Method 1
+
+Follow the [deployment guide](https://github.com/googledatastudio/community-connectors/blob/master/deploy.md) to deploy the Community Connector.
+
+#### Method 2
+
+**Make a copy** of [this script](https://script.google.com/d/1lumxFV7wE0V3mTHrENuSx3rT9XEywJeXYT9dLAz3y-80J_hQR4UoyAS7/edit?usp=sharing) and then **Deploy from manifest...**
+
+## Using the connector in Data Studio
+
+Once you've set up and deployed the connector, follow the [Use a Community Connector](https://developers.google.com/datastudio/connector/use) guide to use the connector in Data Studio.
+
+**Note**: After using the connector in Data Studio, as long as you do not [revoke access](https://support.google.com/datastudio/answer/9053467), it will remain listed in the [connector list](https://datastudio.google.com/c/datasources/create) for easy access when [creating a new data source](https://support.google.com/datastudio/answer/6300774).
+
+### Authentication: API Key
+
+Authenticate to the SendGrid API by [creating an API Key](https://sendgrid.com/docs/ui/account-and-settings/api-keys/#creating-an-api-key) in the Settings section of the SendGrid UI.
+
+> SendGrid recommends API Keys because they are a secure way to talk to the SendGrid API that is separate from your username and password. If your API key gets compromised in any way, it is easy to delete and create a new one and update your environment variables with the new key. An API key permissions can be set to provide access to different functions of your account, without providing full access to your account as a whole.
+
+Refer [SendGrid > Authentication](https://sendgrid.com/docs/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/authentication.html#-API-key-recommended).
+
+You will be prompted to enter this **Key** while setting up the connector for the first time.
+
+![enter-api-key](https://raw.githubusercontent.com/schoraria911/gds-community-connectors/master/SendGrid/Global%20Stats/images/sendgrid-enter-api-key.png)
+
+## Troubleshooting
+
+### This app isn't verified
+
+When authorizing the community connector, if you are presented with an "unverified" warning screen see [This app isn't verified](https://github.com/googledatastudio/community-connectors/blob/master/verification.md) for details on how to proceed.
+
+### Start date is too far in the past
+
+SendGrid's [stats APIs](https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/index.html) provide a read-only access to your email statistics that are available only for the last **3 years** and so if you stumble upon the following error, please change the date range from the data studio viz.
+
+```
+{
+    "errors": [
+        {
+            "message": "start date is too far in the past",
+            "field": "start_date"
+        }
+    ]
+}
+```
+
+## Developer examples covered in the connector
+
+- Using `AuthType.KEY` along with `setCredentials` for [authentication](https://developers.google.com/datastudio/connector/auth)
+- Implementing [Properties Service > User Properties](https://developers.google.com/apps-script/reference/properties/properties-service#getuserproperties) to store and serve SendGrid API Key

--- a/sendgrid/src/Code.gs
+++ b/sendgrid/src/Code.gs
@@ -1,0 +1,283 @@
+/**
+ * Mandatory function required by Google Data Studio that should
+ * return the authentication method required by the connector
+ * to authorize the third-party service.
+ * @return {Object} AuthType
+ */
+function getAuthType() {
+  var cc = DataStudioApp.createCommunityConnector();
+  return cc.newAuthTypeResponse()
+  .setAuthType(cc.AuthType.KEY)
+  .setHelpUrl('https://sendgrid.com/docs/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/authentication.html#-API-key-recommended')
+  .build();
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * clear user credentials for the third-party service.
+ * This function does not accept any arguments and
+ * the response is empty.
+ */
+function resetAuth() {
+  var userProperties = PropertiesService.getUserProperties();
+  userProperties.deleteProperty('dscc.key');
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * determine if the authentication for the third-party service is valid.
+ * @return {Boolean}
+ */
+function isAuthValid() {
+  var userProperties = PropertiesService.getUserProperties();
+  var key = userProperties.getProperty('dscc.key');
+  return checkForValidKey(key);
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * set the credentials after the user enters either their
+ * credential information on the community connector configuration page.
+ * @param {Object} request The set credentials request.
+ * @return {object} An object with an errorCode.
+ */
+function setCredentials(request) {
+  var key = request.key;
+  var validKey = checkForValidKey(key);
+  if (!validKey) {
+    return {
+      errorCode: 'INVALID_CREDENTIALS'
+    };
+  }
+  var userProperties = PropertiesService.getUserProperties();
+  userProperties.setProperty('dscc.key', key);
+  return {
+    errorCode: 'NONE'
+  };
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * return the user configurable options for the connector.
+ * @param {Object} request
+ * @return {Object} fields
+ */
+function getConfig(request) {
+  var cc = DataStudioApp.createCommunityConnector();
+  var config = cc.getConfig();
+  config.setDateRangeRequired(true);
+  return config.build();
+}
+
+/**
+ * Supports the getSchema() function
+ * @param {Object} request
+ * @return {Object} fields
+ */
+function getFields(request) {
+  var cc = DataStudioApp.createCommunityConnector();
+  var fields = cc.getFields();
+  var types = cc.FieldType;
+  var aggregations = cc.AggregationType;
+
+  fields.newDimension()
+  .setId('date')
+  .setType(types.YEAR_MONTH_DAY);
+  
+  fields.newMetric()
+  .setId('blocks')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('bounce_drops')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('bounces')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('clicks')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('deferred')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('delivered')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('invalid_emails')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('opens')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('processed')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('requests')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('spam_report_drops')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('spam_reports')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('unique_clicks')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('unique_opens')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('unsubscribe_drops')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  fields.newMetric()
+  .setId('unsubscribes')
+  .setType(types.NUMBER)
+  .setAggregation(aggregations.SUM);
+  
+  return fields;
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * return the schema for the given request.
+ * This provides the information about how the connector's data is organized.
+ * @param {Object} request
+ * @return {Object} fields
+ */
+function getSchema(request) {
+  var fields = getFields(request).build();
+  return { schema: fields };
+}
+
+/**
+ * Takes the requested fields with the API response and
+ * return rows formatted for Google Data Studio.
+ * @param {Object} requestedFields
+ * @param {Object} response
+ * @return {Array} values
+ */
+function responseToRows(requestedFields, response) {
+  return response.map(function(dailyStats) {
+    var row = [];
+    requestedFields.asArray().forEach(function (field) {
+      switch (field.getId()) {
+        case 'date':
+          return row.push(dailyStats.date);
+        case 'blocks':
+          return row.push(dailyStats.stats[0].metrics.blocks);
+        case 'bounce_drops':
+          return row.push(dailyStats.stats[0].metrics.bounce_drops);
+        case 'bounces':
+          return row.push(dailyStats.stats[0].metrics.bounces);
+        case 'clicks':
+          return row.push(dailyStats.stats[0].metrics.clicks);
+        case 'deferred':
+          return row.push(dailyStats.stats[0].metrics.deferred);
+        case 'delivered':
+          return row.push(dailyStats.stats[0].metrics.delivered);
+        case 'invalid_emails':
+          return row.push(dailyStats.stats[0].metrics.invalid_emails);
+        case 'opens':
+          return row.push(dailyStats.stats[0].metrics.opens);
+        case 'processed':
+          return row.push(dailyStats.stats[0].metrics.processed);
+        case 'requests':
+          return row.push(dailyStats.stats[0].metrics.requests);
+        case 'spam_report_drops':
+          return row.push(dailyStats.stats[0].metrics.spam_report_drops);
+        case 'spam_reports':
+          return row.push(dailyStats.stats[0].metrics.spam_reports);
+        case 'unique_clicks':
+          return row.push(dailyStats.stats[0].metrics.unique_clicks);
+        case 'unique_opens':
+          return row.push(dailyStats.stats[0].metrics.unique_opens);
+        case 'unsubscribe_drops':
+          return row.push(dailyStats.stats[0].metrics.unsubscribe_drops);
+        case 'unsubscribes':
+          return row.push(dailyStats.stats[0].metrics.unsubscribes);
+        default:
+          return row.push('');
+      }
+    });
+    return { values: row };
+  });
+}
+
+/**
+ * Mandatory function required by Google Data Studio that should
+ * return the tabular data for the given request.
+ * @param {Object} request
+ * @return {Object}
+ */
+function getData(request) {
+  var requestedFieldIds = request.fields.map(function(field) {
+    return field.name;
+  });
+  var requestedFields = getFields().forIds(requestedFieldIds);
+  var userProperties = PropertiesService.getUserProperties();
+  var token = userProperties.getProperty('dscc.key');
+  var baseURL = 'https://api.sendgrid.com/v3/stats?start_date=' + request.dateRange.startDate + '&end_date=' + request.dateRange.endDate;
+  var options = {
+    'method' : 'GET',
+    'headers': {
+      'Authorization': 'Bearer ' + token,
+      'Content-Type': 'application/json'
+    },
+    'muteHttpExceptions':true
+  };
+  var response = UrlFetchApp.fetch(baseURL, options);
+  if (response.getResponseCode() == 200) {
+    var parsedResponse = JSON.parse(response);
+    var rows = responseToRows(requestedFields, parsedResponse);
+    return {
+      schema: requestedFields.build(),
+      rows: rows
+    };
+  } else {
+    DataStudioApp.createCommunityConnector()
+    .newUserError()
+    .setDebugText('Error fetching data from API. Exception details: ' + response)
+    .setText('Error fetching data from API. Exception details: ' + response)
+    .throwException();
+  }
+}
+
+/**
+ * Checks if the Key/Token provided by the user is valid
+ * @param {String} key
+ * @return {Boolean}
+ */
+function checkForValidKey(key) {
+  var token = key;
+  var today = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  var baseURL = 'https://api.sendgrid.com/v3/stats?start_date=' + today;  
+  var options = {
+    'method' : 'GET',
+    'headers': {
+      'Authorization': 'Bearer ' + token,
+      'Content-Type': 'application/json'
+    },
+    'muteHttpExceptions':true
+  };
+  var response = UrlFetchApp.fetch(baseURL, options);
+  if (response.getResponseCode() == 200) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/sendgrid/src/appsscript.json
+++ b/sendgrid/src/appsscript.json
@@ -1,0 +1,22 @@
+{
+  "dataStudio": {
+    "name": "SendGrid Global Stats",
+    "company": "script.gs",
+    "companyUrl": "https://script.gs/",
+    "logoUrl": "https://raw.githubusercontent.com/schoraria911/gds-community-connectors/master/SendGrid/Global%20Stats/images/script-gs.png",
+    "addonUrl": "https://github.com/schoraria911/gds-community-connectors/tree/master/SendGrid/Global%20Stats",
+    "supportUrl": "https://github.com/schoraria911/gds-community-connectors/issues/new?title=SendGrid%20Global%20Stats%20Connector%20Issue",
+    "description": "An UNOFFICIAL Google Data Studio Open Source Community Connector for visualising Global Stats of your SendGrid user’s email statistics for a given date range using this API - https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/global.html.",
+    "shortDescription": "UNOFFICIAL Data Studio Community Connector for visualising Global Stats of your SendGrid user’s email statistics.",
+    "authType": ["KEY"],
+    "feeType": ["FREE"],
+    "sources": ["SENDGRID"],
+    "useQueryConfig": false,
+    "templates": {
+      "default": "10KOEVbvyFA0scuj7fj50xt159sSwgubQ"
+    }
+  },
+  "urlFetchWhitelist": [
+    "https://api.sendgrid.com/v3/"
+  ]
+}


### PR DESCRIPTION
This [Data Studio](https://datastudio.google.com) [Community Connector](https://developers.google.com/datastudio/connector) lets you connect to [SendGrid](https://sendgrid.com/)'s [Global Stats API](https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/global.html) and provide all of your user’s email statistics for a given date range.
