### PR TITLE
Update the tooltip text

### DIFF
--- a/gke-usage-metering/src/main.ts
+++ b/gke-usage-metering/src/main.ts
@@ -24,7 +24,7 @@ function getConfig() {
     .setAllowOverride(false)
     .setId('resourceUsageDatasetID')
     .setName('Enter the fully-qualified name of the BigQuery dataset in which the GKE resource usage data resides')
-    .setHelpText('A full-qualified BigQuery dataset name should be in format ${PROJECT_ID}:${DATASET_ID}')
+    .setHelpText('A fully-qualified BigQuery dataset name should be in the format ${PROJECT_ID}.${DATASET_ID}')
     .setPlaceholder('${PROJECT_ID}.${DATASET_ID}');
 
   config
@@ -32,7 +32,7 @@ function getConfig() {
     .setAllowOverride(false)
     .setId('gcpBillingExportTableID')
     .setName('Enter the fully-qualified name of the BigQuery table in which the GCP billing data is exported to')
-    .setHelpText('A full-qualified BigQuery dataset name should be in format PROJECT_ID:DATASET_ID.gcp_billing_export_v1_${BILLING_ACCOUNT_ID}')
+    .setHelpText('A fully-qualified BigQuery dataset name should be in the format PROJECT_ID.DATASET_ID.gcp_billing_export_v1_${BILLING_ACCOUNT_ID}')
     .setPlaceholder('${PROJECT_ID}.${DATASET_ID}.${TABLE_ID}');
 
   config


### PR DESCRIPTION
The connect actually requires the table format to be separated by
periods not colons. Correcting the tooltip text as it created confusion
in some users.